### PR TITLE
Add env variable support and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for development
+REACT_APP_WOOCOMMERCE_URL=https://beegears.com
+REACT_APP_MY_API_KEY=your-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Node modules
+node_modules/
+# Build output
+dist/
+# Environment variables
+.env
+# Local logs
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ npm i
 npm run dev
 ```
 
+### Environment variables
+
+Create a `.env` file in the project root to configure your WooCommerce URL and API key:
+
+```bash
+REACT_APP_WOOCOMMERCE_URL=https://beegears.com
+REACT_APP_MY_API_KEY=<your-api-key>
+```
+
+The `.env` file is ignored by git. Use `.env.example` as a reference when setting up your own environment.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/config/woocommerce.ts
+++ b/src/config/woocommerce.ts
@@ -1,7 +1,9 @@
 
 // WooCommerce backend configuration
 export const WOOCOMMERCE_CONFIG = {
-  baseUrl: process.env.REACT_APP_WOOCOMMERCE_URL || 'https://beegears.com',
+  baseUrl: import.meta.env.REACT_APP_WOOCOMMERCE_URL || 'https://beegears.com',
+  // API key for authenticated requests (optional)
+  apiKey: import.meta.env.REACT_APP_MY_API_KEY || '',
   endpoints: {
     products: '/shop',
     productDetail: '/product',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly REACT_APP_WOOCOMMERCE_URL?: string;
+  readonly REACT_APP_MY_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  // Load environment variables prefixed with REACT_APP_
+  envPrefix: ["VITE_", "REACT_APP_"],
   plugins: [
     react(),
     mode === 'development' &&


### PR DESCRIPTION
## Summary
- ignore `.env` and provide example file
- document environment variables in README
- load REACT_APP_ variables with Vite
- expose WooCommerce API key in config
- type env variables in `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684660467104832386518ffc03a141de